### PR TITLE
Add an option for boolean conversion

### DIFF
--- a/lib/env_helper.ex
+++ b/lib/env_helper.ex
@@ -82,6 +82,53 @@ defmodule EnvHelper do
   end
 
   @doc """
+  creates a method `name/0` which returns either `alt` or the environment variable set for the upcase version `name`, cast to a boolean.
+
+  ## Paramenters
+  * `name` :: atom
+
+     The name of a system environment variable, downcase, as an atom
+  * `alt` :: any
+
+     The value used if the system variable is not set.
+  * :string_to_boolean
+
+    forces the returned value to be a boolean.
+
+  ## Example
+
+      defmodule EnvSets do
+        import EnvHelper
+        system_env(:auto_connect, false, :string_to_boolean)
+      end
+      > EnvSets.auto_connect
+      false
+      > System.put_env("AUTO_CONNECT", "true")
+      :ok
+      > EnvSets.auto_connect
+      true
+      > System.put_env("AUTO_CONNECT", "false")
+      :ok
+      > EnvSets.auto_connect
+      false
+
+  """
+  @spec system_env(atom, any, :string_to_boolean) :: boolean
+  defmacro system_env(name, alt, :string_to_boolean) do
+    env_name = Atom.to_string(name) |> String.upcase
+    quote do
+      def unquote(name)() do
+        value = System.get_env(unquote(env_name)) || unquote(alt)
+        if is_binary(value) do
+          String.downcase(value) not in ["", "false", "nil"]
+        else
+          value && true
+        end
+      end
+    end
+  end
+
+  @doc """
   defines a method `name/0` which returns either the application variable for `appname[key]` or the provided `alt` value.
 
   Works best in simple cases, such as `config :appname, :key, value`

--- a/lib/env_helper.ex
+++ b/lib/env_helper.ex
@@ -120,7 +120,7 @@ defmodule EnvHelper do
       def unquote(name)() do
         value = System.get_env(unquote(env_name)) || unquote(alt)
         if is_binary(value) do
-          String.downcase(value) not in ["", "false", "nil"]
+          not String.downcase(value) in ["", "false", "nil"]
         else
           value && true
         end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule EnvHelper.Mixfile do
 
   def project do
     [app: :env_helper,
-     version: "0.0.5",
+     version: "0.0.6",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/env_helper_test.exs
+++ b/test/env_helper_test.exs
@@ -5,6 +5,12 @@ defmodule TestSettings do
   system_env(:force_int, "4821", :string_to_integer)
   system_env(:must_int, 5432, :string_to_integer)
   system_env(:should_int, 5699, :string_to_integer)
+  system_env(:force_bool_true, "true", :string_to_boolean)
+  system_env(:force_bool_false, "false", :string_to_boolean)
+  system_env(:force_bool_nil, "nil", :string_to_boolean)
+  system_env(:force_bool_empty, "", :string_to_boolean)
+  system_env(:force_bool_words, "not a boolean", :string_to_boolean)
+  system_env(:must_bool, false, :string_to_boolean)
   app_env(:unset, [:env_helper, :unset], "didn't set")
   app_env(:set, [:env_helper, :set], "didn't set")
 
@@ -22,6 +28,7 @@ defmodule SettingsTest do
   setup do
     System.put_env("THIS_GIST", "ghast")
     System.put_env("MUST_INT", "4321")
+    System.put_env("MUST_BOOL", "true")
   end
 
   test "creates methods for simple cases" do
@@ -33,6 +40,15 @@ defmodule SettingsTest do
     assert TestSettings.must_int == 4321
     assert TestSettings.force_int == 4821
     assert TestSettings.should_int == 5699
+  end
+
+  test "allows forcing binary to boolean" do
+    assert TestSettings.force_bool_true == true
+    assert TestSettings.force_bool_false == false
+    assert TestSettings.force_bool_nil == false
+    assert TestSettings.force_bool_empty == false
+    assert TestSettings.force_bool_words == true
+    assert TestSettings.must_bool == true
   end
 
   test "picks up application variables" do


### PR DESCRIPTION
It'd be pretty convenient to have a boolean conversion for yes or no options.

I copied and pasted the `:string_to_integer` stuff and modified it to work with booleans.

I'm open to debate on the coercion behavior, though. I tried to follow the Elixir standards that nothing but `nil` and `false` are 'truthy,' but it may be appropriate to bend the behavior a little. For example, I consider `""` (empty string) to be a falsey value, but it's arguable.